### PR TITLE
Fixes https://github.com/PsyTeachR/quant-fun-v3/issues/6

### DIFF
--- a/include/booktem.css
+++ b/include/booktem.css
@@ -11,7 +11,7 @@
   #TOC, #quarto-sidebar .sidebar-menu-container ul.mt-1 {
     width: 49%;
     padding:0;
-    float: left;
+    float: none;
     display: inline-block;
     vertical-align: text-top;
   }

--- a/include/booktem.css
+++ b/include/booktem.css
@@ -11,8 +11,8 @@
   #TOC, #quarto-sidebar .sidebar-menu-container ul.mt-1 {
     width: 49%;
     padding:0;
-    float: none;
-    display: inline-block;
+    float: left;
+    display: contents;
     vertical-align: text-top;
   }
 }


### PR DESCRIPTION
Table of contents shows below the main index on narrow displays to avoid overlap